### PR TITLE
use compat.v1 imports for tensorflow 2.0 compatibility 

### DIFF
--- a/ncp/models/bbb.py
+++ b/ncp/models/bbb.py
@@ -14,8 +14,9 @@
 
 from tensorflow_probability import distributions as tfd
 import numpy as np
-import tensorflow as tf
 import tensorflow_probability as tfp
+import tensorflow.compat.v1 as tf
+tf.disable_v2_behavior()
 
 from ncp import tools
 

--- a/ncp/models/bbb_ncp.py
+++ b/ncp/models/bbb_ncp.py
@@ -14,7 +14,8 @@
 
 from tensorflow_probability import distributions as tfd
 import numpy as np
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
+tf.disable_v2_behavior()
 import tensorflow_probability as tfp
 
 from ncp import tools

--- a/ncp/models/det.py
+++ b/ncp/models/det.py
@@ -13,7 +13,8 @@
 # limitations under the License.
 
 from tensorflow_probability import distributions as tfd
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
+tf.disable_v2_behavior()
 
 from ncp import tools
 

--- a/ncp/models/det_mix_ncp.py
+++ b/ncp/models/det_mix_ncp.py
@@ -13,7 +13,8 @@
 # limitations under the License.
 
 from tensorflow_probability import distributions as tfd
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
+tf.disable_v2_behavior()
 
 from ncp import tools
 

--- a/ncp/scripts/flights_active.py
+++ b/ncp/scripts/flights_active.py
@@ -21,7 +21,8 @@ import matplotlib as mpl
 mpl.use('Agg')
 import matplotlib.pyplot as plt
 import ruamel.yaml as yaml
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
+tf.disable_v2_behavior()
 
 from ncp import datasets
 from ncp import models

--- a/ncp/scripts/toy_active.py
+++ b/ncp/scripts/toy_active.py
@@ -21,7 +21,8 @@ import matplotlib as mpl
 mpl.use('Agg')
 import matplotlib.pyplot as plt
 import ruamel.yaml as yaml
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
+tf.disable_v2_behavior()
 
 from ncp import datasets
 from ncp import models

--- a/ncp/tools/training.py
+++ b/ncp/tools/training.py
@@ -18,7 +18,8 @@ import sys
 
 import numpy as np
 import scipy.stats
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
+tf.disable_v2_behavior()
 
 from ncp.tools import attrdict
 from ncp.tools import plotting


### PR DESCRIPTION
Title says it all really, very minor changes.
Tested on the toy problem with tensorflow 2.1.0 and python 3.6.9